### PR TITLE
Integrate Apple script to launch zwift and Spotify

### DIFF
--- a/code.py
+++ b/code.py
@@ -84,9 +84,9 @@ while True:
     while ble.connected:
         trackball.set_rgbw(0, 0, 254, 0)
         up, down, left, right, switch, state = trackball.read()
-        if state:
-            # Press enter
-            k.send(Keycode.ENTER)
+        if not startBtn.value:
+            # If we get a start, trigger applescript on laptop with key combo `ctrl`+`shift`+`=`.
+            k.send(Keycode.CONTROL, Keycode.SHIFT, Keycode.EQUALS)
         if not btn2.value:
             # Play or Pause media
             consumer_control.send(ConsumerControlCode.PLAY_PAUSE)
@@ -99,17 +99,20 @@ while True:
         if not btn5.value:
             # Press TAB to skip workout block
             k.send(Keycode.TAB)
-        # Logic for Trackball directions
-        if up > 10:
+        # Logic for Trackball controller
+        if state:
+            # Press enter
+            k.send(Keycode.ENTER)
+        if left > 10:
             # Press up arrow key
             k.send(Keycode.UP_ARROW)
-        if down > 10:
+        if right > 10:
             # Press down arrow key
             k.send(Keycode.DOWN_ARROW)
-        if left > 10:
+        if down > 10:
             # Press left arrow key
             k.send(Keycode.LEFT_ARROW)
-        if right > 10:
+        if up > 10:
             k.send(Keycode.RIGHT_ARROW)
         
         time.sleep(0.1)

--- a/notes.md
+++ b/notes.md
@@ -32,3 +32,10 @@ list files
 >>> import os                                                                   
 >>> os.listdir() 
 ```
+
+### Apple Script Setup:
+
+how to launch an applescript from a keyboard shortcut? https://apple.stackexchange.com/a/276839
+
+Had a problem with making the zwift initial laucher window click the "Let's Go" button, had to hack around it by clicking the menu items as here: https://apple.stackexchange.com/questions/350940/use-applescript-to-raise-and-focus-on-window 
+

--- a/zwiftendo-launcher
+++ b/zwiftendo-launcher
@@ -1,0 +1,37 @@
+# Invoke Spotify to open
+open location "spotify"
+
+# Make sure we have the spotify-application on front and in focus
+tell application "Spotify"
+	activate
+	# start playing Zwift FTP smasher playlist
+	play track "spotify:playlist:6z8HXp2HUhaotHBzsWGoAY"
+end tell
+
+# Start the Zwift launcher
+tell application "Zwift" to activate
+
+tell application "System Events"
+	# Wait until the Zwift game itself starts
+	repeat until (exists process "Zwift")
+		delay 1
+	end repeat
+	
+	tell process "Zwift"
+		# make Zwift the active window
+		set frontmost to true
+		click (first menu item whose name contains "Zwift") of menu "Window" of menu bar 1
+		
+		delay 3
+		keystroke return
+		
+		# Wait until the main game window is available
+		repeat until (exists window 1)
+			delay 1
+		end repeat
+		
+		
+		# set full screen
+		set value of attribute "AXFullScreen" of window 1 to true
+	end tell
+end tell


### PR DESCRIPTION
Script is launched via the key combo `ctrl` + `shift`+`=` and triggers an automator services